### PR TITLE
Added OS X support for md5 command

### DIFF
--- a/logwatcher.py
+++ b/logwatcher.py
@@ -1,4 +1,4 @@
-#!/bin/env python2.7
+#!/usr/bin/env python2.7
 
 import re
 import sys

--- a/package.sh
+++ b/package.sh
@@ -5,4 +5,12 @@ tgzname=$1_$version
 tar -czf $tgzname.tgz *
 mv $tgzname.tgz ..
 cd ..
-md5sum $tgzname.tgz
+
+if [ $(uname -s) == 'Darwin' ]
+then
+  md5cmd='md5'
+else
+  md5cmd='md5sum'  
+fi
+
+$md5cmd $tgzname.tgz

--- a/package.sh
+++ b/package.sh
@@ -13,4 +13,7 @@ else
   md5cmd='md5sum'  
 fi
 
-$md5cmd $tgzname.tgz
+md5sum=$($md5cmd $tgzname.tgz)
+
+echo $md5sum > $tgzname.md5
+echo $md5sum


### PR DESCRIPTION
The tool to calculate md5sums on OS X is `md5`, the default linux `md5sum` is not available. Using a `uname -s` check, the command is changed to `md5` it `Darwin` is returned as system. Otherwise `md5sum` is used as default tool.