### PR TITLE
MQTT password

### DIFF
--- a/logwatcher.py
+++ b/logwatcher.py
@@ -56,14 +56,14 @@ def connect(ip, username, password):
     sys.exit(1)
 
 if __name__ == '__main__':
-    if len(sys.argv) != 4:
-        print 'Usage: ./logwatcher.py <ip/hostname of gateway> <username> <plugin>'
+    if len(sys.argv) < 4:
+        print 'Usage: ./logwatcher.py <ip/hostname of gateway> <username> <plugin> <password>'
         sys.exit(1)
     try:
         _ip = sys.argv[1]
         _username = sys.argv[2]
         _plugin = sys.argv[3]
-        _password = getpass.getpass('Password: ')
+        _password = sys.argv[4] if len(sys.argv) > 4 else getpass.getpass('Password: ')
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", exceptions.InsecureRequestWarning)
             watch(_ip, _username, _password, _plugin)


### PR DESCRIPTION
logwatcher:

 - add the fourth parameter "password" to connect without interactive password prompt

MQTT Plugin:

 - add username/password options
 - fix some PEP8 issues
 - fix issues with unicode hostname/username/password

Setting 'hostname' from web gui failed, raising an exception here:

```
            if item['type'] == 'str':
                if not isinstance(config[name], str):
                    raise PluginException("Config '%s': '%s' is not a string" % (name, config[name])
```

Because `type(config[name])` was `unicode` instead of `str`