### PR TITLE
Add plugin to support synchronisation with tasmota devices (HTTP only)

### DIFF
--- a/tasmotaHTTP/LICENSE.txt
+++ b/tasmotaHTTP/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2020 Tiago Pires
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/tasmotaHTTP/README.md
+++ b/tasmotaHTTP/README.md
@@ -1,0 +1,39 @@
+# Tasmota HTTP
+
+An Tasmota HTTP plugin for synchronising tasmota devices with OpenMotics virtual outputs.
+
+## Work in progress
+
+This is a work in progress, but has already been extensively tested in a real home. This plugin is shared for community feedback and/or contributions. Please only use this plugin if you know what you're doing and if you're willing to debug issues you might encounter. As always, feel free to report issues and/or make pull requests.
+
+## Configuration
+
+### Add a virtual output
+
+First you will need to add a virtual output. For that, use the command line from the local or cloud web portal.
+According to the [wiki](https://wiki.openmotics.com/index.php/Virtual_Outputs), virtual outputs can be created from the command line.
+
+```shell
+# check for errors before adding a virtual output
+[openmotics]$ error list ;if there are errors, clean them with error clear command.
+# create a virtual output; it should return OK
+[openmotics]$ add virtual module o
+OK
+# check again for errors
+[openmotics]$ error list
+# that's it
+# you now have 8 new outputs available to use
+```
+
+### Plugin
+
+1. Add the refresh interval (in seconds) to update all tasmota devices on `refresh_interval` field
+2. On `tasmota_mapping` click on `Add section`
+3. Add a `label` to uniquely identify this device
+4. Add the device IP address on `ip_address`
+5. If the tasmota device is authenticated fill in `username` and `password`
+6. Pick one output id from the 8 newly created from previous step (i.e. 60)
+7. If you've more tasmota devices to synchronise, repeat step 2 to 6.
+8. Save
+
+On Logs section, Tasmota HTTP plugin will become enable and it will print the initial tasmota state and any future changes.

--- a/tasmotaHTTP/main.py
+++ b/tasmotaHTTP/main.py
@@ -1,0 +1,131 @@
+"""
+An Tasmota HTTP plugin
+"""
+
+import time
+import requests
+import simplejson as json
+from plugins.base import om_expose, OMPluginBase, PluginConfigChecker, background_task
+
+
+class TasmotaHTTP(OMPluginBase):
+    """
+    An Tasmota HTTP plugin
+    """
+
+    name = 'tasmotaHTTP'
+    version = '1.0.0'
+    interfaces = [('config', '1.0')]
+
+    config_description = [{'name': 'refresh_interval',
+                           'type': 'int',
+                           'description': 'Refresh interval (in seconds) to fetch values from outputs and push to tasmota devices'},
+                          {'name': 'tasmota_mapping',
+                           'type': 'section',
+                           'description': 'Mapping betweet OpenMotics Virtual Sensors and Tasmota devices. See README.',
+                           'repeat': True,
+                           'min': 0,
+                           'content': [{'name': 'label',
+                                        'type': 'str',
+                                        'description': 'Name to identify pair (ip_address, output_id)'},
+                                       {'name': 'ip_address',
+                                        'type': 'str',
+                                        'description': 'Device IP Address.'},
+                                       {'name': 'username',
+                                        'type': 'str',
+                                        'description': 'Device username, fill only if authentication is enabled.'},
+                                       {'name': 'password',
+                                        'type': 'password',
+                                        'description': 'Device password, fill only if authentication is enabled.'},
+                                       {'name': 'output_id',
+                                        'type': 'int',
+                                        'description':'OpenMotics output id to sync with Tasmota'}]}]
+
+    default_config = {'refresh_interval': 2}
+    tasmota_http_endpoint = 'http://{ip_address}/cm?user={user}&password={password}&cmnd=Power%20{action}'
+
+    def __init__(self, webinterface, logger):
+        super(TasmotaHTTP, self).__init__(webinterface, logger)
+        self.logger('Starting Tasmota HTTP plugin...')
+
+        self._config = self.read_config(TasmotaHTTP.default_config)
+        self._config_checker = PluginConfigChecker(TasmotaHTTP.config_description)
+
+        self._read_config()
+
+        self._previous_output_state = {}
+
+        self.logger("Started Tasmota HTTP plugin")
+
+    def _read_config(self):
+        self._refresh_interval = self._config.get('refresh_interval', 5)
+
+        tasmota_mapping = self._config.get('tasmota_mapping', [])
+        self._tasmota_mapping = tasmota_mapping
+        self._headers = {'X-Requested-With': 'OpenMotics plugin: Tasmota HTTP'}
+        self._enabled = bool(self._tasmota_mapping)
+
+        self.logger('Tasmota HTTP is {0}'.format('enabled' if self._enabled else 'disabled'))
+
+    @background_task
+    def run(self):
+        previous_values = {}
+        while True:
+            if self._enabled:
+                try:
+                    result = json.loads(self.webinterface.get_output_status())
+                    if 'status' in result:
+                        for device in self._tasmota_mapping:
+                            if not isinstance(device['output_id'], int):
+                                continue
+                            device_output_id = device['output_id']
+
+                            for output in result['status']:
+                                output_id = output['id']
+                                if output_id != device_output_id:
+                                    continue
+                                if device['label'] in previous_values and previous_values[device['label']] == output['status']:
+                                    continue
+                                previous_values[device['label']] = self.update_tasmota(device, output)
+                                self.logger('Tasmota device {0} is {1}'.format(device['label'], 'on' if output['status'] == 1 else 'off'))
+                except Exception as ex:
+                    self.logger('Failed to get output status: {0}'.format(ex))
+
+                # Wait a given amount of seconds
+                time.sleep(self._refresh_interval)
+            else:
+                time.sleep(5)
+
+    @om_expose
+    def get_config_description(self):
+        return json.dumps(TasmotaHTTP.config_description)
+
+    @om_expose
+    def get_config(self):
+        return json.dumps(self._config)
+
+    @om_expose
+    def set_config(self, config):
+        config = json.loads(config)
+        for key in config:
+            if isinstance(config[key], basestring):
+                config[key] = str(config[key])
+        self._config_checker.check_config(config)
+        self._config = config
+        self._read_config()
+        self.write_config(config)
+        return json.dumps({'success': True})
+
+    def update_tasmota(self, device, output):
+        response = requests.get(url=self.tasmota_http_endpoint.format(ip_address=device['ip_address'],
+                                                                           user=device['username'],
+                                                                           password=device['password'],
+                                                                           action=output['status']),
+                                headers=self._headers)
+        if response.status_code == 200:
+            if response.json()['POWER'] == 'ON':
+                return 1
+        else:
+            self.logger('Failed to update Tasmota device {0}: {1}'.format(device['ip_address'], response.status_code))
+
+        return 0


### PR DESCRIPTION
Allows synchronisation between OpenMotics virtual outputs and tasmota devices through HTTP.

Signed-off-by: Tiago Pires <tandrepires@gmail.com>