### PR TITLE
Removal of 'floor' attribute

### DIFF
--- a/mqtt-client/main.py
+++ b/mqtt-client/main.py
@@ -21,7 +21,7 @@ class MQTTClient(OMPluginBase):
     """
 
     name = 'MQTTClient'
-    version = '2.0.0'
+    version = '2.0.1'
     interfaces = [('config', '1.0')]
 
     energy_module_config = {
@@ -387,7 +387,6 @@ class MQTTClient(OMPluginBase):
                                                                     'O': 'output',
                                                                     'd': 'dimmer',
                                                                     'D': 'dimmer'}[config['module_type']],
-                                                    'floor': config['floor'],
                                                     'type': 'relay' if config['type'] == 0 else 'light'}
                     for output_id in self._outputs.keys():
                         if output_id not in ids:


### PR DESCRIPTION
Fix for removal of 'floor' attribute from OutputSerializer by OpenMotics