### PR TITLE
Fix hotwater and ventilation errors.

### DIFF
--- a/dummy/info.json
+++ b/dummy/info.json
@@ -1,5 +1,5 @@
 {
-    "version" : "2.2.0",
+    "version" : "2.2.1",
     "description" : "dummy",
     "metric_source"  : "dummy",
     "metric_type" : "dummy",

--- a/dummy/main.py
+++ b/dummy/main.py
@@ -34,7 +34,7 @@ class Dummy(OMPluginBase):
     """
 
     name = "Dummy"
-    version = "2.2.0"
+    version = "2.2.1"
     interfaces = [("config", "1.0")]
 
     default_config = {}
@@ -446,13 +446,13 @@ class Dummy(OMPluginBase):
         logger.debug("new hot water status from gateway: {}".format(status))
 
     @staticmethod
-    def handle_hot_water_status(event):
+    def handle_hot_water_status(event_data):
         logger.debug(
             "Received hot_water status from gateway: {0} {1} {2} {3} {4}".format(
-                event.data["id"],
-                event.data["state"],
-                event.data["setpoint"],
-                event.data["steering_power"],
-                event.data["current_temperature"],
+                event_data["id"],
+                event_data["state"],
+                event_data["setpoint"],
+                event_data["steering_power"],
+                event_data["current_temperature"],
             )
         )

--- a/dummy/ventilation.py
+++ b/dummy/ventilation.py
@@ -66,7 +66,7 @@ class VentilationDummy:
             new_remaining_time = (
                 self._expiry - now if self._expiry and now <= self._expiry else None
             )
-            if new_remaining_time >= 0:
+            if new_remaining_time and new_remaining_time >= 0:
                 new_expiry = self._expiry
                 new_mode = self.mode
             else:


### PR DESCRIPTION
Bump version to 2.2.1

## Errors:

### Hotwater
- `handle_hot_water_status` function is receiving `event.data` from plugin runtime in GW. So it doesnt need to access `event.data`.

### Ventilation
-  `new_remaining_time` can be null while the if clause depending on it being a number. So it first checks the existence of `new_remaining_time`.

